### PR TITLE
client(refactor): use environment variable for portfolio URL in sidebar

### DIFF
--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -298,7 +298,7 @@ const Sidebar: FC<SidebarProps> = ({ isMenuOpen, setIsMenuOpen }) => {
                 )}
             </div>
 
-            <p className="mt-3 text-center text-[12px]">Copyright © 2026 <a href="https://laxman-thedev.vercel.app" className='underline' >Laxman</a> IntelliChat</p>
+            <p className="mt-3 text-center text-[12px]">Copyright © 2026 <a href={import.meta.env.VITE_PORTFOLIO_URL} className='underline' >Laxman</a> IntelliChat</p>
 
             {/* Mobile close button */}
             <img


### PR DESCRIPTION
This pull request makes a small improvement to the `Sidebar` component by updating the portfolio link to use an environment variable for greater flexibility and configurability.

- The `Sidebar` component now uses the `VITE_PORTFOLIO_URL` environment variable for the portfolio link, instead of hardcoding the URL.