### PR TITLE
client(config): add Vercel rewrites for proper routing on refresh

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/index.html"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request introduces a `vercel.json` configuration file to the client, which sets up a rewrite rule for routing all requests to `index.html`. This is typically done to enable client-side routing in single-page applications.

Deployment configuration:

* Added a `vercel.json` file with a rewrite rule that directs all incoming requests to `index.html`, supporting client-side routing for the application.